### PR TITLE
Added shortcuts for commands

### DIFF
--- a/src/main/java/org/nexial/installer/CommandLineOptions.java
+++ b/src/main/java/org/nexial/installer/CommandLineOptions.java
@@ -39,27 +39,32 @@ public class CommandLineOptions {
 
         Iterator<String> argIterator = Arrays.stream(args).iterator();
         argIterator.forEachRemaining(option -> {
-            switch (option) {
-                case "-" + OPT_LIST: {
+            switch ("-" + option) {
+                case OPT_LIST:
+                case OPT_LIST_L:{
                     options.setListOnly(true);
                     break;
                 }
-                case "-" + OPT_INSTALL: {
+                case OPT_INSTALL:
+                case OPT_INSTALL_I: {
                     if (!argIterator.hasNext()) { throw new IllegalArgumentException("No version specified"); }
                     options.setVersion(argIterator.next());
                     break;
                 }
-                case "-" + OPT_TARGET: {
+                case OPT_TARGET:
+                case OPT_TARGET_T: {
                     if (!argIterator.hasNext()) { throw new IllegalArgumentException("No target directory specified"); }
                     options.setInstallTarget(argIterator.next());
                     break;
                 }
-                case "-" + OPT_BACKUP: {
+                case OPT_BACKUP:
+                case OPT_BACKUP_B: {
                     if (!argIterator.hasNext()) { throw new IllegalArgumentException("No backup directory specified"); }
                     options.setBackupTarget(argIterator.next());
                     break;
                 }
-                case "-" + OPT_KEEP_DOWNLOADED: {
+                case OPT_KEEP_DOWNLOADED:
+                case OPT_KEEP_DOWNLOADED_KD: {
                     options.setKeepDownloaded(true);
                     break;
                 }

--- a/src/main/java/org/nexial/installer/Const.java
+++ b/src/main/java/org/nexial/installer/Const.java
@@ -70,6 +70,13 @@ final class Const {
     protected static final String OPT_BACKUP = "backup";
     protected static final String OPT_KEEP_DOWNLOADED = "keepDownloaded";
     protected static final String OPT_QUIT = "quit";
+    protected static final String OPT_LIST_L = "L";
+    protected static final String OPT_INSTALL_I = "I";
+    protected static final String OPT_CONFIGURE_C = "C";
+    protected static final String OPT_TARGET_T = "T";
+    protected static final String OPT_BACKUP_B = "B";
+    protected static final String OPT_KEEP_DOWNLOADED_KD = "KD";
+    protected static final String OPT_QUIT_Q = "Q";
     protected static final String VER_LATEST = "latest";
 
     protected static final int ERR_MISSING_VERSION = -2;

--- a/src/main/java/org/nexial/installer/NexialInstaller.java
+++ b/src/main/java/org/nexial/installer/NexialInstaller.java
@@ -143,10 +143,10 @@ public class NexialInstaller {
         // String input = in.nextLine();
         String input = readStdin();
 
-        while (input != null && !input.equals(OPT_QUIT)) {
+        while (input != null && !(OPT_QUIT.equals(input) || OPT_QUIT_Q.equals(input))) {
             input = input.trim();
             if (input.length() > 0) {
-                if (OPT_QUIT.equals(input)) { break; }
+                if (OPT_QUIT.equals(input) || OPT_QUIT_Q.equals(input)) { break; }
 
                 int splitIndex = input.indexOf(" ");
                 String command = splitIndex == -1 ? input : input.substring(0, splitIndex);
@@ -180,10 +180,10 @@ public class NexialInstaller {
 
     protected static void showOptions() {
         System.out.println("OPTIONS:");
-        System.out.println("\t" + OPT_LIST + "\t\t- list the Nexial versions currently available for download.");
-        System.out.println("\t" + OPT_INSTALL + "\t\t- install a specific version or latest.");
-        System.out.println("\t" + OPT_CONFIGURE + "\t- customize installation location.");
-        System.out.println("\t" + OPT_QUIT + "\t\t- exit.");
+        System.out.println("\t" + OPT_LIST + " (" + OPT_LIST_L + ")" + "\t- list the Nexial versions currently available for download.");
+        System.out.println("\t" + OPT_INSTALL + " (" + OPT_INSTALL_I + ")" + "\t- install a specific version or latest.");
+        System.out.println("\t" + OPT_CONFIGURE + " (" + OPT_CONFIGURE_C + ")" + "\t- customize installation location.");
+        System.out.println("\t" + OPT_QUIT + " (" + OPT_QUIT_Q + ")" + "\t- exit.");
         System.out.print("COMMAND: ");
     }
 
@@ -236,24 +236,24 @@ public class NexialInstaller {
     }
 
     protected static void handleCommand(String command, String version) throws IOException {
-        if (OPT_LIST.equals(command)) {
+        if (OPT_LIST.equals(command) || OPT_LIST_L.equals(command)) {
             showVersions();
             exitCode = 0;
             return;
         }
 
-        if (OPT_CONFIGURE.equals(command)) {
+        if (OPT_CONFIGURE.equals(command) || OPT_CONFIGURE_C.equals(command)) {
             configure();
             exitCode = 0;
             return;
         }
 
-        if (OPT_INSTALL.equals(command)) {
+        if (OPT_INSTALL.equals(command) || OPT_INSTALL_I.equals(command)) {
             if (StringUtils.isBlank(version)) {
                 showError("Please specify either latest or a specific version to install");
                 System.err.println("For example:");
-                System.err.println("\tinstall latest");
-                System.err.println("\tinstall nexial-core-v1.9_0400");
+                System.err.println("\t" + OPT_INSTALL + " latest or " + OPT_INSTALL_I + " latest");
+                System.err.println("\t" + OPT_INSTALL + " nexial-core-v1.9_0400 or " + OPT_INSTALL_I + " nexial-core-v1.9_0400");
                 exitCode = ERR_MISSING_VERSION;
                 return;
             }


### PR DESCRIPTION
Added short cut commands to follow through installation steps:
Eg. 

```
OPTIONS:
	list (L)	- list the Nexial versions currently available for download.
	install (I)	- install a specific version or latest.
	configure (C)	- customize installation location.
	quit (Q)	- exit.
```

Here, the letters in caps work the same as their respective full-length command. The user can skip typing the whole word if s/he wishes.

